### PR TITLE
ci: switch base branch to release

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [master]
+    branches: [release]
   pull_request:
-    branches: [master]
+    branches: [release]
 
 jobs:
   build:


### PR DESCRIPTION
Let's use the `release` branch for releases, and leave `master` to indicate how far ahead/behind we are.