### PR TITLE
Use logger instead of fmt.Println in browser.go

### DIFF
--- a/pkg/provider/browser/browser.go
+++ b/pkg/provider/browser/browser.go
@@ -2,7 +2,6 @@ package browser
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"regexp"
 
@@ -94,7 +93,7 @@ var getSAMLResponse = func(page playwright.Page, loginDetails *creds.LoginDetail
 		return "", err
 	}
 
-	fmt.Println("waiting ...")
+	logger.Info("waiting ...")
 	r, _ := page.WaitForRequest(signin_re)
 	data, err := r.PostData()
 	if err != nil {


### PR DESCRIPTION
Upstream fix:

> `fmt.Println` still logs when `--quiet` is specified and that's problematic when saml2login is being used as credential_process in aws profiles.